### PR TITLE
Refine design module hover meta

### DIFF
--- a/r_d_capability_audit_html.backup.html
+++ b/r_d_capability_audit_html.backup.html
@@ -16,7 +16,7 @@
   .mod-head{display:flex;justify-content:space-between;align-items:center}
   .badge{background:#eef6ff;color:#0366d6;border:1px solid #cfe3ff;padding:2px 8px;border-radius:999px;font-size:12px}
   .pill{padding:2px 8px;border-radius:8px;background:#f6f6f6;border:1px solid #eaeaea;font-size:12px;color:#444}
-  .scorebox{width:64px}
+  select.scorebox{min-width:280px}
   .notes{width:100%}
   .footer{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
   .legend{font-size:12px;color:#555}
@@ -830,6 +830,36 @@ fetch('revise/revise.md')
   .then(text=>applyReviseMeta(text))
   .catch(()=>{});
 
+// Build a single <option> using rubric text for level n; fallback to generic label if missing
+function optionHtml(n, text){
+  const FALLBACK = {
+    1: '1 无系统',
+    2: '2 非正式',
+    3: '3 有文件并执行',
+    4: '4 有效运行且闭环',
+    5: '5 自动化数据驱动'
+  };
+  const label = text ? `${n} ${text}` : FALLBACK[n];
+  // title attribute helps show full text on hover if select text is truncated
+  return `<option value="${n}" title="${text ? (n + ' ' + text) : FALLBACK[n]}">${label}</option>`;
+}
+
+// Render a scorebox for module key + question index, pulling per-question rubric first
+function renderScorebox(modKey, qIndex){
+  const module = MODEL.find(m => m.key === modKey);
+  const q = module && module.questions ? module.questions[qIndex] : null;                 // q can be a string or an object {text, rubric, meta...}
+  const rubric = (q && q.rubric)
+              || (window.RUBRICS && RUBRICS[modKey] && RUBRICS[modKey][qIndex])
+              || null;
+
+  return `
+    <select class="scorebox" data-module="${modKey}" data-index="${qIndex}" onchange="recalc()">
+      <option value="">—</option>
+      ${[1,2,3,4,5].map(n => optionHtml(n, rubric ? rubric[String(n)] : null)).join('')}
+    </select>
+  `;
+}
+
 /** 动态渲染清单 **/
 const host = document.getElementById('modules');
 MODEL.forEach((m, mi) => {
@@ -854,15 +884,8 @@ MODEL.forEach((m, mi) => {
                 </ul>
               </details>
             </td>
-            <td>
-              <select class="scorebox" data-module="${m.key}" onchange="recalc()">
-                <option value="">—</option>
-                <option value="1">1 无系统</option>
-                <option value="2">2 非正式</option>
-                <option value="3">3 有文件并执行</option>
-                <option value="4">4 有效运行且闭环</option>
-                <option value="5">5 自动化数据驱动</option>
-              </select>
+            <td class="score-cell">
+              ${renderScorebox(m.key, qi)}
             </td>
             <td><input class="notes" placeholder="证据/链接/记录编号（如：DFMEA#2025-03, DRR纪要, TVS选型表 等）"/></td>
           </tr>
@@ -1022,15 +1045,19 @@ function exportJSON(){
   const payload = { modules: [] };
   MODEL.forEach(m=>{
     // 导出时同步题目文本与逐级打分口径，确保数据闭环
+    const moduleDef = MODEL.find(mm=>mm.key===m.key);
     const rows=[...document.querySelectorAll(`select[data-module="${m.key}"]`)].map((s,idx)=>{
       const tr = s.closest('tr');
-      const qObj = m.questions[idx];
-      const meta = qObj.meta || {};
+      const qObj = moduleDef && moduleDef.questions ? moduleDef.questions[idx] : null;
+      const meta = (qObj && qObj.meta) || {};
+      const rubric = (qObj && qObj.rubric)
+                  || (window.RUBRICS && RUBRICS[m.key] && RUBRICS[m.key][idx])
+                  || null;
       return {
-        q: qObj.text,
+        q: (qObj && qObj.text) ? qObj.text : qObj,
         score: Number(s.value||0),
         note: tr.querySelector('input.notes').value||"",
-        rubric: {...qObj.rubric},
+        rubric: rubric,
         meta:{
           focus: Array.isArray(meta.focus)?[...meta.focus]:[],
           ask: Array.isArray(meta.ask)?[...meta.ask]:[],

--- a/r_d_capability_audit_html.html
+++ b/r_d_capability_audit_html.html
@@ -316,9 +316,34 @@ function defaultMeta(modKey, text){
 }
 
 function decorateModel(){
+  const KEYS = ['focus','ask','evidence','threshold'];
   MODEL.forEach(module=>{
-    module.questions.forEach((q,idx)=>{
-      q.meta = defaultMeta(module.key, q.text);
+    module.questions.forEach((q, idx)=>{
+      if(typeof q === 'string'){
+        q = { text: q };
+        module.questions[idx] = q;
+      }
+      const fallback = defaultMeta(module.key, q.text);
+      if(!q.meta){
+        q.meta = fallback;
+      } else {
+        KEYS.forEach(key=>{
+          const arr = Array.isArray(q.meta[key])
+            ? q.meta[key].map(item => (typeof item === 'string' ? item.trim() : item)).filter(Boolean)
+            : [];
+          let unique = Array.from(new Set(arr));
+          if(unique.length > 1){
+            unique = unique.filter(item => item !== '（暂无条目）');
+          }
+          if(!unique.length){
+            q.meta[key] = [...fallback[key]];
+          } else if(unique.length === 1 && unique[0] === '（暂无条目）' && module.key !== 'design'){
+            q.meta[key] = [...fallback[key]];
+          } else {
+            q.meta[key] = unique;
+          }
+        });
+      }
       q._normKey = normalizeKey(q.text);
       q._index = idx;
     });
@@ -824,6 +849,63 @@ const MODEL = [
   }
 ];
 
+(function normalizeDesignQuestions(){
+  const design = MODEL.find(m => m.key === 'design');
+  if(!design) return;
+
+  function liTextsFromUl(ulHtml){
+    return Array.from(ulHtml.matchAll(/<li>([\s\S]*?)<\/li>/gi))
+      .map(m => m[1].replace(/<[^>]+>/g,' ').replace(/\s+/g,' ').trim())
+      .filter(Boolean);
+  }
+
+  function distributeToMeta(liList){
+    const meta = { focus:[], ask:[], evidence:[], threshold:[] };
+    liList.forEach(t => {
+      const s = t.trim();
+      if (/^(关注点|要点)[:：]/.test(s)) {
+        meta.focus.push(s.replace(/^[^:：]+[:：]\s*/, '').trim() || s);
+      } else if (/^(怎么问|问法|如何确认)[:：]/.test(s)) {
+        meta.ask.push(s.replace(/^[^:：]+[:：]\s*/, '').trim() || s);
+      } else if (/^(期望证据|证据|证明材料)[:：]/.test(s)) {
+        const rest = s.replace(/^[^:：]+[:：]\s*/, '').trim() || s;
+        rest.split(/[、，,；;]/).map(x=>x.trim()).filter(Boolean).forEach(x=>meta.evidence.push(x));
+      } else if (/^(建议门槛|门槛|判定标准|目标等级)[:：]/.test(s)) {
+        const rest = s.replace(/^[^:：]+[:：]\s*/, '').trim() || s;
+        rest.split(/[、，,；;]/).map(x=>x.trim()).filter(Boolean).forEach(x=>meta.threshold.push(x));
+      } else {
+        meta.focus.push(s);
+      }
+    });
+    ['focus','ask','evidence','threshold'].forEach(k=>{
+      meta[k] = Array.from(new Set(meta[k]));
+    });
+    return meta;
+  }
+
+  design.questions.forEach(q => {
+    const html = String(q.text || '');
+    const ulMatch = html.match(/<ul[\s\S]*?<\/ul>/i);
+    const titleOnly = html.replace(/<ul[\s\S]*?<\/ul>/gi, '').trim();
+    q.text = titleOnly || (q.text && q.text.replace(/<[^>]+>/g,' ').trim()) || q.text;
+
+    const baseMeta = q.meta || { focus:[], ask:[], evidence:[], threshold:[] };
+    if(ulMatch){
+      const ulHtml = ulMatch[0];
+      const li = liTextsFromUl(ulHtml);
+      const parsed = distributeToMeta(li);
+      ['focus','ask','evidence','threshold'].forEach(k=>{
+        const set = new Set([...(baseMeta[k]||[]), ...(parsed[k]||[])].filter(Boolean));
+        baseMeta[k] = Array.from(set);
+      });
+    }
+    ['focus','ask','evidence','threshold'].forEach(k=>{
+      baseMeta[k] = baseMeta[k] && baseMeta[k].length ? baseMeta[k] : ['（暂无条目）'];
+    });
+    q.meta = baseMeta;
+  });
+})();
+
 decorateModel();
 fetch('revise/revise.md')
   .then(res=>res.ok?res.text():Promise.reject())
@@ -873,23 +955,31 @@ MODEL.forEach((m, mi) => {
     <table>
       <thead><tr><th style="width:44px">#</th><th>问题（Questions）</th><th style="width:110px">得分(1-5)</th><th>证据/备注</th></tr></thead>
       <tbody>
-        ${m.questions.map((q, qi) => `
+        ${m.questions.map((question, qi) => {
+          const q = (typeof question === 'string') ? { text: question } : question;
+          const qText = q && q.text ? q.text : '';
+          const rubric = q && q.rubric ? q.rubric : null;
+          const rubricHtml = rubric ? `
+              <details class="rubric"><summary>查看打分口径</summary>
+                <ul>
+                  ${['1','2','3','4','5'].map(level => `<li><b>${level}分：</b>${rubric[level] || ''}</li>`).join('')}
+                </ul>
+              </details>
+            ` : '';
+          return `
           <tr>
             <td>${qi+1}</td>
             <td class="qtext" data-module="${m.key}" data-index="${qi}" tabindex="0">
-              <div>${q.text}</div>
-              <details class="rubric"><summary>查看打分口径</summary>
-                <ul>
-                  ${['1','2','3','4','5'].map(level => `<li><b>${level}分：</b>${q.rubric[level]}</li>`).join('')}
-                </ul>
-              </details>
+              <div>${qText}</div>
+              ${rubricHtml}
             </td>
             <td class="score-cell">
               ${renderScorebox(m.key, qi)}
             </td>
             <td><input class="notes" placeholder="证据/链接/记录编号（如：DFMEA#2025-03, DRR纪要, TVS选型表 等）"/></td>
           </tr>
-        `).join('')}
+          `;
+        }).join('')}
       </tbody>
     </table>
     <div class="footer">
@@ -928,7 +1018,7 @@ const radar = new Chart(ctx,{
 });
 
 function getMeta(modKey, idx){
-  const fallback = { focus:['暂无'], ask:['暂无'], evidence:['暂无'], threshold:['暂无'] };
+  const fallback = { focus:['（暂无条目）'], ask:['（暂无条目）'], evidence:['（暂无条目）'], threshold:['（暂无条目）'] };
   const module = MODEL.find(m=>m.key===modKey);
   const question = module && module.questions[idx];
   if(!question) return fallback;


### PR DESCRIPTION
## Summary
- move the design module inline bullet details into each question's metadata and strip the display text down to the concise prompt
- preserve existing question metadata when decorating the model so parsed hover content and placeholders survive
- harden the question table rendering to handle missing rubrics while keeping hover hooks and rubric text in the score dropdowns

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68cc24710d24832bbcbca226d7aa6e05