### PR TITLE
Improve PDF extraction heuristics and add PDF tests

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install -e .[dev] pypdf python-docx beautifulsoup4 lxml ruff mypy pytest
+      - run: pip install -e .[dev] pypdf pdfminer.six pikepdf python-docx beautifulsoup4 lxml ruff mypy pytest
       - name: Guard against legacy harvester paths
         run: |
           set -e

--- a/README_harvester.md
+++ b/README_harvester.md
@@ -16,6 +16,12 @@ python basic_knowledge/scripts/harvest_methods.py update
 python basic_knowledge/scripts/harvest_methods.py render
 ```
 
+For richer PDF extraction install the optional backends:
+
+```bash
+pip install pypdf pdfminer.six pikepdf
+```
+
 Use `--root` to point the CLI to another checkout or sandbox. The `check`
 command performs a dry-run to show which files would be parsed and whether they
 changed since the last update.
@@ -56,7 +62,8 @@ make test     # run ruff, mypy, and pytest
 ## Troubleshooting
 
 - **Missing dependencies** – install via `pip install -e .[dev]` to pull in
-  `beautifulsoup4`, `lxml`, `pypdf`, `python-docx`, and tooling.
+  `beautifulsoup4`, `lxml`, `pypdf`, `python-docx`, and tooling. Add
+  `pdfminer.six` and `pikepdf` for resilient PDF extraction.
 - **PDF extraction is empty** – not all PDFs contain embedded text. The harvester
   logs a warning and continues without blocking the run.
 - **No items detected** – ensure section headings contain words such as

--- a/basic_knowledge/method_harvester/parser.py
+++ b/basic_knowledge/method_harvester/parser.py
@@ -2,17 +2,26 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
+import tempfile
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from hashlib import sha256
 from pathlib import Path
+from typing import Any
 
 from bs4 import BeautifulSoup
 from docx import Document
-from pypdf import PdfReader
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_PDF_BACKENDS = [
+    "pypdf",
+    "pdfminer",
+    "pikepdf+pypdf",
+    "pikepdf+pdfminer",
+]
 
 SUPPORTED_EXTENSIONS = {
     ".md",
@@ -83,6 +92,38 @@ FIELD_ALIASES: dict[str, str] = {
     "keywords": "tags",
 }
 
+_PDF_FIELD_NAMES = sorted({alias for alias in FIELD_ALIASES}, key=len, reverse=True)
+_PDF_FIELD_PATTERN = (
+    "|".join(re.escape(name) for name in _PDF_FIELD_NAMES) if _PDF_FIELD_NAMES else None
+)
+_PDF_FIELD_LEADING_RE = (
+    re.compile(rf"(?<!\n)(?P<alias>(?:{_PDF_FIELD_PATTERN})):", re.IGNORECASE)
+    if _PDF_FIELD_PATTERN
+    else None
+)
+_PDF_FIELD_BREAK_RE = (
+    re.compile(rf"(?i)(?P<alias>(?:{_PDF_FIELD_PATTERN})):(?!\s*\n)")
+    if _PDF_FIELD_PATTERN
+    else None
+)
+
+PDF_TITLE_STOPWORDS = {
+    "and",
+    "or",
+    "the",
+    "of",
+    "for",
+    "to",
+    "a",
+    "an",
+    "in",
+    "on",
+    "with",
+    "at",
+    "by",
+    "from",
+}
+
 
 @dataclass
 class ParsedItem:
@@ -114,9 +155,10 @@ class FileScanResult:
     extracted_count: int
     status: str = "pending"
     error: str | None = None
+    pdf_meta: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        data: dict[str, object] = {
             "file": self.file,
             "sha256": self.sha256,
             "mtime": self.mtime,
@@ -124,6 +166,473 @@ class FileScanResult:
             "status": self.status,
             "error": self.error,
         }
+        if self.pdf_meta is not None:
+            data["pdf_meta"] = self.pdf_meta
+        return data
+
+
+@dataclass
+class ParseOutcome:
+    """Result of parsing a file, including optional PDF metadata."""
+
+    items: list[ParsedItem]
+    pdf_meta: dict[str, Any] | None = None
+
+
+def _resolve_backend_order(prefer_backends: Iterable[str] | None) -> list[str]:
+    if prefer_backends:
+        order = [backend.strip() for backend in prefer_backends if backend and backend.strip()]
+    else:
+        env_value = os.environ.get("HARVEST_PDF_BACKENDS")
+        if env_value:
+            order = [backend.strip() for backend in env_value.split(",") if backend.strip()]
+        else:
+            order = list(DEFAULT_PDF_BACKENDS)
+    seen = set()
+    unique_order: list[str] = []
+    for backend in order:
+        if backend not in seen:
+            unique_order.append(backend)
+            seen.add(backend)
+    return unique_order or list(DEFAULT_PDF_BACKENDS)
+
+
+def _dedupe(sequence: Iterable[str]) -> list[str]:
+    seen = set()
+    result: list[str] = []
+    for item in sequence:
+        if item and item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result
+
+
+def _is_xref_issue(message: str | None) -> bool:
+    if not message:
+        return False
+    lowered = message.lower()
+    return "xref" in lowered or "cross" in lowered
+
+
+def resolve_min_pdf_chars(value: int | None) -> int:
+    if value is not None:
+        return max(value, 0)
+    env_value = os.environ.get("HARVEST_MIN_PDF_CHARS")
+    if env_value:
+        try:
+            return max(int(env_value), 0)
+        except ValueError:
+            logger.debug("Invalid HARVEST_MIN_PDF_CHARS value: %s", env_value)
+    return 200
+
+
+def extract_pdf_text(
+    path: str | Path,
+    *,
+    min_chars: int = 200,
+    prefer_backends: Iterable[str] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Extract text from a PDF using a cascading set of backends."""
+
+    pdf_path = Path(path)
+    try:
+        byte_size = pdf_path.stat().st_size
+    except OSError:
+        byte_size = 0
+
+    backend_order = _resolve_backend_order(prefer_backends)
+    best_text = ""
+    best_chars = 0
+    best_backend = "none"
+    best_repaired = False
+    best_warnings: list[str] = []
+    last_error: str | None = None
+    all_warnings: list[str] = []
+    any_repaired = False
+    needs_repair_hint = False
+    attempts_had_output = False
+
+    with tempfile.TemporaryDirectory(prefix="harvest_pdf_") as tmp_dir:
+        repair_info: tuple[Path, list[str]] | None = None
+        repair_error: str | None = None
+
+        for backend_name in backend_order:
+            backend_name = backend_name.strip()
+            if not backend_name:
+                continue
+
+            use_repair = backend_name.startswith("pikepdf+")
+            base_backend = backend_name.split("+", 1)[-1] if use_repair else backend_name
+            attempt_warnings: list[str] = []
+            attempt_error: str | None = None
+            repaired = False
+            target_path = pdf_path
+
+            if use_repair:
+                if repair_info is None and repair_error is None:
+                    try:
+                        repair_info = _repair_pdf_with_pikepdf(pdf_path, Path(tmp_dir))
+                    except Exception as exc:  # pragma: no cover - pikepdf optional
+                        repair_error = str(exc)
+                        logger.debug("pikepdf repair failed for %s: %s", pdf_path, exc)
+                if repair_info is None:
+                    attempt_error = repair_error or "pikepdf repair unavailable"
+                    attempt_warnings.append(f"pikepdf repair failed: {attempt_error}")
+                    all_warnings.extend(
+                        f"{backend_name}: {warning}" for warning in attempt_warnings
+                    )
+                    last_error = attempt_error
+                    continue
+                target_path, repair_warnings = repair_info
+                attempt_warnings.extend(repair_warnings)
+                repaired = True
+                any_repaired = True
+
+            try:
+                text, backend_warnings = _extract_with_backend(base_backend, target_path)
+                attempt_warnings.extend(backend_warnings)
+            except Exception as exc:  # pragma: no cover - backend errors depend on deps
+                attempt_error = str(exc)
+                if _is_xref_issue(attempt_error):
+                    needs_repair_hint = True
+                logger.debug("PDF backend %s failed for %s: %s", base_backend, pdf_path, exc)
+                text = ""
+
+            chars = len(text)
+            if text.strip():
+                attempts_had_output = True
+                if chars > best_chars:
+                    best_chars = chars
+                    best_text = text
+                    best_backend = backend_name
+                    best_repaired = repaired
+                    best_warnings = list(attempt_warnings)
+            else:
+                attempt_warnings.append("extracted text empty")
+
+            if chars < min_chars and text.strip():
+                attempt_warnings.append(
+                    f"extracted text shorter than min_chars ({chars} < {min_chars})"
+                )
+
+            if any(_is_xref_issue(message) for message in attempt_warnings):
+                needs_repair_hint = True
+
+            if attempt_error:
+                last_error = attempt_error
+
+            all_warnings.extend(f"{backend_name}: {warning}" for warning in attempt_warnings)
+
+            if chars >= min_chars and text.strip() and not needs_repair_hint and not attempt_error:
+                break
+
+        if best_chars >= min_chars and best_text.strip():
+            meta = {
+                "backend": best_backend,
+                "bytes": byte_size,
+                "chars": best_chars,
+                "warnings": _dedupe(best_warnings),
+                "repaired": best_repaired,
+                "error": None,
+            }
+            return best_text, meta
+
+    warnings_out = list(_dedupe(all_warnings))
+    if best_chars and best_chars < min_chars:
+        warnings_out.append(f"best text shorter than min_chars ({best_chars} < {min_chars})")
+    if not attempts_had_output and not last_error:
+        warnings_out.append("no backend produced text")
+    meta = {
+        "backend": "none",
+        "bytes": byte_size,
+        "chars": best_chars,
+        "warnings": _dedupe(warnings_out),
+        "repaired": any_repaired,
+        "error": last_error,
+    }
+    return "", meta
+
+
+def _extract_with_backend(backend: str, path: Path) -> tuple[str, list[str]]:
+    if backend == "pypdf":
+        return _extract_with_pypdf(path)
+    if backend == "pdfminer":
+        return _extract_with_pdfminer(path)
+    raise RuntimeError(f"unknown backend: {backend}")
+
+
+def _extract_with_pypdf(path: Path) -> tuple[str, list[str]]:
+    warnings: list[str] = []
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("pypdf is not installed") from exc
+
+    try:
+        reader = PdfReader(str(path))
+    except Exception as exc:  # pragma: no cover - upstream errors vary
+        raise RuntimeError(str(exc)) from exc
+
+    text_chunks: list[str] = []
+    for page_number, page in enumerate(reader.pages, start=1):
+        try:
+            text = page.extract_text() or ""
+        except Exception as exc:  # pragma: no cover - depends on document
+            warnings.append(f"page {page_number}: {exc}")
+            text = ""
+        text_chunks.append(text)
+    return "\n".join(text_chunks), warnings
+
+
+def _extract_with_pdfminer(path: Path) -> tuple[str, list[str]]:
+    try:
+        from pdfminer.high_level import extract_text
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("pdfminer.six is not installed") from exc
+
+    try:
+        text = extract_text(str(path))
+    except Exception as exc:  # pragma: no cover - upstream errors vary
+        raise RuntimeError(str(exc)) from exc
+    return text or "", []
+
+
+def _repair_pdf_with_pikepdf(source: Path, temp_dir: Path) -> tuple[Path, list[str]]:
+    try:
+        from pikepdf import Pdf  # type: ignore[attr-defined]
+    except ImportError as exc:  # pragma: no cover - optional dependency
+        raise RuntimeError("pikepdf is not installed") from exc
+
+    repaired_path = Path(temp_dir) / "repaired.pdf"
+    warnings: list[str] = ["pikepdf repair applied"]
+    try:
+        with Pdf.open(str(source)) as pdf:
+            pdf.save(str(repaired_path))
+    except Exception as exc:  # pragma: no cover - upstream errors vary
+        raise RuntimeError(str(exc)) from exc
+    return repaired_path, warnings
+
+
+def _insert_pdf_field_breaks(text: str) -> str:
+    if not text:
+        return text
+    updated = text
+    if _PDF_FIELD_LEADING_RE is not None:
+        def add_leading(match: re.Match[str]) -> str:
+            alias = match.group("alias")
+            prefix = "" if match.start() == 0 else "\n"
+            return f"{prefix}{alias}:"
+
+        updated = _PDF_FIELD_LEADING_RE.sub(add_leading, updated)
+    if _PDF_FIELD_BREAK_RE is not None:
+        def ensure_break(match: re.Match[str]) -> str:
+            alias = match.group("alias")
+            return f"{alias}:\n"
+
+        updated = _PDF_FIELD_BREAK_RE.sub(ensure_break, updated)
+    return updated
+
+
+def _normalise_pdf_text(text: str) -> str:
+    cleaned = _insert_pdf_field_breaks(text)
+    lines = cleaned.splitlines()
+    if not lines:
+        return cleaned
+    _move_list_items_after_field(
+        lines,
+        (
+            "anti-patterns",
+            "antipatterns",
+            "pitfalls",
+            "watch-outs",
+            "warnings",
+        ),
+    )
+    output: list[str] = []
+    seen_heading = False
+    pending_steps: list[str] = []
+    seen_steps_field = False
+    release_pending_after_number = False
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            output.append(raw_line)
+            continue
+        if (
+            not seen_steps_field
+            and stripped[:1].isdigit()
+            and LIST_PREFIX_RE.match(stripped)
+        ):
+            pending_steps.append(raw_line)
+            continue
+        lowered = stripped.lower()
+        if lowered.startswith("steps:"):
+            seen_steps_field = True
+            release_pending_after_number = bool(pending_steps)
+            output.append(raw_line)
+            continue
+        if (
+            release_pending_after_number
+            and stripped[:1].isdigit()
+            and LIST_PREFIX_RE.match(stripped)
+        ):
+            output.append(raw_line)
+            if pending_steps:
+                output.extend(
+                    sorted(pending_steps, key=_numbered_line_key)
+                )
+                pending_steps.clear()
+            release_pending_after_number = False
+            continue
+        if not seen_heading:
+            heading = stripped.lstrip("#").strip()
+            if not heading:
+                heading = stripped
+            output.append(f"## {heading}")
+            seen_heading = True
+            continue
+        if stripped.startswith("###") and not stripped.endswith(":"):
+            heading = stripped.lstrip("#").strip()
+            if heading and not KEYWORD_PATTERN.search(heading):
+                output.append(f"## {heading}")
+                continue
+        output.append(raw_line)
+    if pending_steps:
+        output.extend(pending_steps)
+    _move_list_items_after_field(
+        output,
+        (
+            "anti-patterns",
+            "antipatterns",
+            "pitfalls",
+            "watch-outs",
+            "warnings",
+        ),
+    )
+    return "\n".join(output)
+
+
+def _rotate_pdf_lines(text: str) -> str:
+    lines = text.splitlines()
+    if not lines:
+        return text
+    def find_candidate(skip_hash: bool) -> int | None:
+        for index, raw_line in enumerate(lines):
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            if skip_hash and stripped.startswith("#"):
+                continue
+            if _looks_like_pdf_title(raw_line):
+                return index
+        return None
+
+    best_index = find_candidate(True)
+    if best_index is None:
+        best_index = find_candidate(False)
+    if best_index is None:
+        for index, raw_line in enumerate(lines):
+            stripped = raw_line.strip()
+            if not stripped:
+                continue
+            if stripped.endswith(":"):
+                continue
+            if stripped[0] in "-*•" or stripped[:1].isdigit():
+                continue
+            best_index = index
+            break
+    if best_index is None or best_index == 0:
+        return text
+    rotated = lines[best_index:] + lines[:best_index]
+    return "\n".join(rotated)
+
+
+def _looks_like_pdf_title(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped:
+        return False
+    if stripped[0] in "-*•":
+        return False
+    if stripped[:1].isdigit():
+        return False
+    base = stripped.lstrip("#").strip()
+    base = re.sub(r"^[\-•*]+\s*", "", base)
+    base = re.sub(r"^[\d\.\)]+\s*", "", base)
+    if not base:
+        return False
+    if any(char in base for char in (":", "|")):
+        return False
+    if any(char in base for char in ".!?"):
+        return False
+    tokens = [re.sub(r"[^A-Za-z0-9']", "", token) for token in base.split()]
+    tokens = [token for token in tokens if token]
+    if not tokens:
+        return False
+    has_alpha = False
+    for token in tokens:
+        if token.isdigit():
+            continue
+        if not any(char.isalpha() for char in token):
+            continue
+        has_alpha = True
+        lower = token.lower()
+        if lower in PDF_TITLE_STOPWORDS:
+            continue
+        if token.isupper() or token[0].isupper():
+            continue
+        return False
+    return has_alpha
+
+
+def _numbered_line_key(line: str) -> int:
+    match = re.match(r"\s*(\d+)", line)
+    if match:
+        try:
+            return int(match.group(1))
+        except ValueError:  # pragma: no cover - defensive
+            return 0
+    return 0
+
+
+def _move_list_items_after_field(lines: list[str], aliases: Iterable[str]) -> None:
+    alias_prefixes = [alias.lower().rstrip(":") for alias in aliases]
+    if not alias_prefixes:
+        return
+    for index, raw_line in enumerate(list(lines)):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        lowered = stripped.lower()
+        matched_alias = next(
+            (alias for alias in alias_prefixes if lowered.startswith(alias)), None
+        )
+        if not matched_alias:
+            continue
+        removal_indices: list[int] = []
+        moved: list[str] = []
+        scan_index = index - 1
+        while scan_index >= 0:
+            candidate = lines[scan_index]
+            candidate_stripped = candidate.strip()
+            if not candidate_stripped:
+                scan_index -= 1
+                continue
+            if candidate_stripped.startswith(('-', '*', '•')):
+                moved.append(candidate)
+                removal_indices.append(scan_index)
+                scan_index -= 1
+                continue
+            break
+        if not moved:
+            return
+        for position in sorted(removal_indices):
+            lines.pop(position)
+        field_index = index - len(removal_indices)
+        insertion_index = field_index + 1
+        for line_value in reversed(moved):
+            lines.insert(insertion_index, line_value)
+            insertion_index += 1
+        return
 
 
 def iter_supported_files(root: Path) -> Iterator[Path]:
@@ -143,22 +652,29 @@ def slugify(text: str) -> str:
     return cleaned
 
 
-def parse_file(path: Path, base_path: Path) -> list[ParsedItem]:
+def parse_file(
+    path: Path,
+    base_path: Path,
+    *,
+    min_pdf_chars: int | None = None,
+    pdf_backends: Iterable[str] | None = None,
+) -> ParseOutcome:
     suffix = path.suffix.lower()
     if suffix in {".md", ".markdown"}:
         text = path.read_text(encoding="utf-8", errors="ignore")
-        return parse_markdown(text, path, base_path)
+        return ParseOutcome(parse_markdown(text, path, base_path))
     if suffix == ".txt":
         text = path.read_text(encoding="utf-8", errors="ignore")
-        return parse_plain_text(text, path, base_path)
+        return ParseOutcome(parse_plain_text(text, path, base_path))
     if suffix in {".html", ".htm"}:
         text = path.read_text(encoding="utf-8", errors="ignore")
-        return parse_html(text, path, base_path)
+        return ParseOutcome(parse_html(text, path, base_path))
     if suffix == ".pdf":
-        return parse_pdf(path, base_path)
+        effective_min = resolve_min_pdf_chars(min_pdf_chars)
+        return parse_pdf(path, base_path, min_chars=effective_min, pdf_backends=pdf_backends)
     if suffix == ".docx":
-        return parse_docx(path, base_path)
-    return []
+        return ParseOutcome(parse_docx(path, base_path))
+    return ParseOutcome([])
 
 
 def parse_markdown(text: str, path: Path, base_path: Path) -> list[ParsedItem]:
@@ -282,20 +798,31 @@ def parse_html(text: str, path: Path, base_path: Path) -> list[ParsedItem]:
     return items
 
 
-def parse_pdf(path: Path, base_path: Path) -> list[ParsedItem]:
-    try:
-        reader = PdfReader(str(path))
-    except Exception as exc:  # pragma: no cover - heavy dependency errors
-        logger.warning("Failed to read PDF %s: %s", path, exc)
-        return []
-    text_chunks = []
-    for page in reader.pages:
-        try:
-            text_chunks.append(page.extract_text() or "")
-        except Exception:  # pragma: no cover - upstream behaviour
-            continue
-    text = "\n".join(text_chunks)
-    return parse_plain_text(text, path, base_path)
+def parse_pdf(
+    path: Path,
+    base_path: Path,
+    *,
+    min_chars: int,
+    pdf_backends: Iterable[str] | None,
+) -> ParseOutcome:
+    text, meta = extract_pdf_text(path, min_chars=min_chars, prefer_backends=pdf_backends)
+    if not text.strip():
+        return ParseOutcome([], meta)
+
+    ordered_text = _rotate_pdf_lines(text)
+    candidates = [ordered_text]
+    normalised = _normalise_pdf_text(ordered_text)
+    if normalised != ordered_text:
+        candidates.insert(0, normalised)
+
+    items: list[ParsedItem] = []
+    for candidate in candidates:
+        items = parse_markdown(candidate, path, base_path)
+        if items:
+            break
+    if not items:
+        items = parse_plain_text(ordered_text, path, base_path)
+    return ParseOutcome(items, meta)
 
 
 def parse_docx(path: Path, base_path: Path) -> list[ParsedItem]:
@@ -314,6 +841,10 @@ def is_candidate_heading(heading: str, lines: list[str]) -> bool:
     snippet = " ".join(line.strip() for line in lines[:4])
     if KEYWORD_PATTERN.search(snippet):
         return True
+    for line in lines[:8]:
+        stripped = line.strip().rstrip(":").lower()
+        if stripped in FIELD_ALIASES:
+            return True
     # Accept headings that are fully uppercase (often a name) if section has cues.
     if heading.isupper() and any("step" in line.lower() for line in lines):
         return True
@@ -394,10 +925,16 @@ def split_list(value: str) -> list[str]:
 
 
 def scan_directory(
-    target_dir: Path, base_path: Path
+    target_dir: Path,
+    base_path: Path,
+    *,
+    min_pdf_chars: int | None = None,
+    pdf_backends: Iterable[str] | None = None,
 ) -> tuple[list[ParsedItem], dict[str, FileScanResult]]:
     items: list[ParsedItem] = []
     files: dict[str, FileScanResult] = {}
+    resolved_min = resolve_min_pdf_chars(min_pdf_chars)
+    resolved_backends = list(pdf_backends) if pdf_backends else None
     for file_path in iter_supported_files(target_dir):
         rel_file = str(file_path.relative_to(base_path).as_posix())
         try:
@@ -418,7 +955,12 @@ def scan_directory(
         file_sha = sha256(raw_bytes).hexdigest()
         mtime = int(file_path.stat().st_mtime)
         try:
-            parsed = parse_file(file_path, base_path)
+            parsed = parse_file(
+                file_path,
+                base_path,
+                min_pdf_chars=resolved_min,
+                pdf_backends=resolved_backends,
+            )
         except Exception as exc:  # pragma: no cover - defensive
             logger.exception("Failed to parse %s", file_path)
             files[rel_file] = FileScanResult(
@@ -430,14 +972,15 @@ def scan_directory(
                 error=str(exc),
             )
             continue
-        for item in parsed:
+        for item in parsed.items:
             item.file_sha = file_sha
             items.append(item)
         files[rel_file] = FileScanResult(
             file=rel_file,
             sha256=file_sha,
             mtime=mtime,
-            extracted_count=len(parsed),
+            extracted_count=len(parsed.items),
+            pdf_meta=parsed.pdf_meta,
         )
     return items, files
 

--- a/basic_knowledge/tests/test_pdf_extract.py
+++ b/basic_knowledge/tests/test_pdf_extract.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import base64
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from basic_knowledge.method_harvester import normalize, parser
+from basic_knowledge.method_harvester.parser import extract_pdf_text
+from basic_knowledge.scripts import harvest_methods
+
+PDF_TEXT_SIMPLE_B64 = (
+    "JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZy AvUGFnZXMgMi AwIFIgPj4KZW5kb2Jq"
+    "CjIgMCBvYmoKPD wgL1R5cGU gL1BhZ2Vz IC9Db3Vud CAx IC9LaWRz IFsz IDAgUl0gPj4KZW5kb2Jq"
+    "CjMgMCBvYmoKPD wgL1R5cGU gL1BhZ2 UgL1BhcmVud CAy IDAgUi AvTWVkaWFCb3ggWzAgMCA2MTIg"
+    "NzkyXS AvQ29udGVud HMgNCAw IFIgL1Jlc291cmNlcy A8PCAvRm9ud CA8PCAvRjEgNS Aw IFIgPj4 g"
+    "Pj4 gPj4KZW5kb2JqCjQgMC BvYmoKPD wgL0xlb md0a CA2MDMgPj4Kc3RyZWFtCkJUCi9GMS AxMi BU"
+    "Zgox IDAgMCAx IDcy IDEwMC BUbQooRml2ZSBXaHlzKS BUagoxIDAgMCAx IDcyIDExOC BUbQooIyMj"
+    "IE1vZGVsKS BUagoxIDAgMCAx ID72 IDEzNi BUbQooV2hlbiB0byB1c2U6KS BUagox IDAgMCAx ID72 IDE1NC"
+    "BUbQooLS BJbnZlc3RpZ2F0ZSByZWN1cnJpbmcgaXNzdWVzIHF1aWNrbHkgd2l0aCBzaW1wbGUgcXVl"
+    "c3Rpb25pbmcuKS BUagox IDAgMCAx ID72 IDE3Mi BUbQooU3RlcHM6KS BUagox IDAgMCAx ID72 IDE5MC BU"
+    "bQooMS4gRGVmaW5lIHRoZSBwcm9ibGVtIHdpdGggb2JzZXJ2YWJsZSBmYWN0cyBhbmQgY29udGV4dC4p"
+    "IFRqCjEgMCAwIDEgNzIgMjA4IFRtCigyLi BBc2sgd2h5IHJlcGVhdGVkbHkgdW50aWwgdGhlIHJvb3Qg"
+    "Y2F1c2UgaXMgdW5kZXJzdG9vZC4p IFRqCjEgMCAwIDEgNzIgMjI2 IFRtCigzLi BBZGRyZXNzIHRoZSB1"
+    "bmRlcmx5aW5nIGNhdXNlIHdpdGggY29ycmVjdGl2ZSBhY3Rpb24uKS BUagox IDAgMCAx ID72 IDI0NC BUbQ"
+    "ooQW50aS1wYXR0ZXJuczop IFRqCjEgMCAw IDE gNzIgMjYy IFRtCigtIEFjY2VwdGluZyBzdXBlcmZpY2lh"
+    "bCBhbnN3ZXJzIG9yIGJsYW1pbmcgaW5kaXZpZHVhbHMgcHJlbWF0dXJlbHkuKS BUagpFVAplbmRzdHJlYW0"
+    "KZW5kb2JqCjUgMC BvYmoKPD wgL1R5cGU gL0Zvbn QgL1N1YnR5cGU gL1R5cGUx IC9CYXNlRm9ud C AvSGVs"
+    "dmV0aWNh ID4+CmVuZG9iagp4cmVmCjAgNgowMDAwMDAwMDAw IDY1NTM1 IGY gCjAwMDAwMDAwMDkgMDAwMDA"
+    "gbi AKMDAwMDAwMDA1OCAwMDAwMC Bu IAowMDAwMDAwMTE1 IDAwMDAw IG4 gCjAwMDAwMDAyNDE gMDAwMDAg"
+    "bi AKMDAwMDAwMDg5NS AwMDAwMC Bu IAp0cmFpbGVyCjw8 IC9TaXpl IDY gL1Jvb3QgMS Aw IFIgPj4Kc3Rh"
+    "cnR4cmVmCjk2NQolJUVPRgo="
+)
+
+PDF_BROKEN_XREF_B64 = (
+    "JVBERi0xLjQKMS AwIG9iago8PCAvVHlwZS AvQ2F0YWxvZy AvUGFnZX MgMi Aw IFIgPj4KZW5kb2Jq"
+    "CjIgMC BvYmoKPD wgL1R5cGU gL1BhZ2Vz IC9Db3Vud CAx IC9LaWRz IFsz IDAgUl0 gPj4KZW5kb2Jq"
+    "CjMgMC BvYmoKPD wgL1R5cGU gL1BhZ2 UgL1BhcmVud CAy IDAgUi AvTWVkaWFCb3ggWzAgMCA2MTIg"
+    "NzkyXS AvQ29udGVud HMgNCAw IFIgL1Jlc291cmNlcy A8PCAvRm9ud CA8PCAvRjEgNS Aw IFIgPj4 g"
+    "Pj4 gPj4KZW5kb2JqCjQgMC BvYmoKPD wgL0xlb md0a CAzMjIgPj4Kc3RyZWFtCkJUCi9GMS AxMi BU"
+    "Zgox IDAgMCAx ID72 IDEwMC BUbQooRGVjaXNpb24gTWF0cml4KS BUagox IDAgMCAx ID72 IDExOC BUbQ"
+    "ooVXNlIHdoZW46KS BUagox IDAgMCAx ID72 IDEzNi BUbQooLS BD b21wYXJpbmc gbXVsdGlwbGUgb3B0aW9u"
+    "cyB3aXRoIHdlaWdodGVkIGNyaXRlcmlhLikgVGoKMS Aw IDAgMS A3Mi AxNTQgVG0KKFN0ZXBzOik gVGoKMS Aw"
+    "IDAgMS A3Mi AxNzIgVG0KKDEu IExpc3QgYWx0ZXJuYXRpdmVzLikgVGoKMS Aw IDAgMS A3Mi AxOTAgVG0KKDIu"
+    "IERlZmluZ SBjcml0ZXJpYS4p IFRqCjEgMCAw IDE gNzIgMjA4 IFRtCigzLi BTY29yZ SBhbmQgc3VtLik gVGoKRVQ"
+    "KZW5kc3RyZWFtCmVuZG9iago1 IDAgb2JqCjw8 IC9UeXBl IC9Gb250 IC9TdWJ0eXBl IC9UeXBlMS AvQmFzZUZv"
+    "bnQgL0hlbHZldGljYSA+PgplbmRvYmoKeHJlZgow IDYKMDAwMDAwMDAwMCA2NTUzNS Bm IAowMDAwMDAwMDA5"
+    "IDAwMDAw IG4 gCjAwMDAwMDAwNT ggMDAwMDA gbi AKMDAwMDAwMDExNS AwMDAwMC Bu IAowMDAwMDAwMjQx IDAw"
+    "MDAw IG4 gCjAwMDAwMDA2MTQg MDAwMDA gbi AKdHJhaWxlcgo8PCAvU2l6Z SA2 IC9Sb290 IDE gMC BS ID4+"
+    "CnN0YXJ0eHJlZgowCiUlRU9GCg=="
+)
+
+PDF_IMAGE_ONLY_B64 = (
+    "JVBERi0xLjQKMS AwIG9iago8PCAvVHlwZS AvQ2F0YWxvZy AvUGFnZX MgMi Aw IFIgPj4KZW5kb2Jq"
+    "CjIgMC BvYmoKPD wgL1R5cGU gL1BhZ2Vz IC9Db3Vud CAx IC9LaWRz IFsz IDAgUl0 gPj4KZW5kb2Jq"
+    "CjMgMC BvYmoKPD wgL1R5cGU gL1BhZ2 UgL1BhcmVud CAy IDAgUi AvTWVkaWFCb3ggWzAgMCA2MTIg"
+    "NzkyXS AvQ29udGVud HMgNCAw IFIgL1Jlc291cmNlcy A8PCAvRm9ud CA8PCAvRjEgNS Aw IFIgPj4 g"
+    "Pj4 gPj4KZW5kb2JqCjQgMC BvYmoKPD wgL0xlb md0a CAxNSA+PgpzdHJlYW0KQlQKL0Yx IDEy IFRm"
+    "CkVUCmVuZHN0cmVhbQplbmRvYmoKNS Aw IG9iago8PCAvVHlwZS AvRm9ud C AvU3VidHlwZS AvVHlwZTE gL0Jh"
+    "c2VGb250 IC9IZWx2ZXRpY2 EgPj4KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZi AKMDAwMDAw"
+    "MDAwOS AwMDAwMC Bu IAowMDAwMDAwMDU4 IDAwMDAw IG4 gCjAwMDAwMDAxMTUgMDAwMDA gbi AKMDAwMDAwMDI0MS"
+    "AwMDAwMC Bu IAowMDAwMDAwMzA2 IDAwMDAw IG4 gCnRyYWlsZXIKPDwgL1Npem UgNi AvUm9vd CAx IDAgUi A+Pgpz"
+    "dGFydHhyZWYKMzc2CiUlRU9GCg=="
+)
+
+BACKENDS = ["pypdf", "pdfminer", "pikepdf+pypdf", "pikepdf+pdfminer"]
+
+
+@pytest.fixture()
+def pdf_text_simple(tmp_path: Path) -> Path:
+    path = tmp_path / "five_whys.pdf"
+    path.write_bytes(base64.b64decode(PDF_TEXT_SIMPLE_B64))
+    return path
+
+
+@pytest.fixture()
+def pdf_broken_xref(tmp_path: Path) -> Path:
+    path = tmp_path / "decision_matrix.pdf"
+    path.write_bytes(base64.b64decode(PDF_BROKEN_XREF_B64))
+    return path
+
+
+@pytest.fixture()
+def pdf_image_only(tmp_path: Path) -> Path:
+    path = tmp_path / "diagram.pdf"
+    path.write_bytes(base64.b64decode(PDF_IMAGE_ONLY_B64))
+    return path
+
+
+def test_extract_pdf_text_simple_pypdf_or_pdfminer_ok(
+    tmp_path: Path, pdf_text_simple: Path
+) -> None:
+    text, meta = extract_pdf_text(pdf_text_simple, min_chars=200, prefer_backends=BACKENDS)
+    assert text.strip()
+    assert meta["chars"] >= 200
+    assert meta["backend"] in set(BACKENDS)
+
+    root = tmp_path / "repo"
+    target = root / "basic_knowledge" / "method_frame"
+    target.mkdir(parents=True)
+    shutil.copy(pdf_text_simple, target / pdf_text_simple.name)
+
+    items, files = parser.scan_directory(
+        target, root, min_pdf_chars=200, pdf_backends=BACKENDS
+    )
+    names = {item.name for item in items}
+    assert "Five Whys" in names
+    rel_path = f"basic_knowledge/method_frame/{pdf_text_simple.name}"
+    assert rel_path in files
+    assert files[rel_path].pdf_meta is not None
+    assert files[rel_path].pdf_meta.get("backend") in set(BACKENDS)
+
+
+def test_extract_pdf_text_repairs_broken_xref(pdf_broken_xref: Path) -> None:
+    text, meta = extract_pdf_text(pdf_broken_xref, min_chars=150, prefer_backends=BACKENDS)
+    assert "Matrix" in text
+    assert meta["backend"] in {"pdfminer", "pikepdf+pypdf", "pikepdf+pdfminer"}
+    if meta["backend"].startswith("pikepdf"):
+        assert meta.get("repaired")
+
+
+def test_extract_pdf_text_image_only_returns_empty(
+    tmp_path: Path, pdf_image_only: Path
+) -> None:
+    text, meta = extract_pdf_text(pdf_image_only, min_chars=150, prefer_backends=BACKENDS)
+    assert text == ""
+    assert meta["chars"] < 150
+    assert meta["backend"] in {"none"} | set(BACKENDS)
+
+    root = tmp_path / "repo"
+    target = root / "basic_knowledge" / "method_frame"
+    target.mkdir(parents=True)
+    shutil.copy(pdf_image_only, target / pdf_image_only.name)
+    _, files = parser.scan_directory(target, root, min_pdf_chars=150, pdf_backends=BACKENDS)
+    rel_path = f"basic_knowledge/method_frame/{pdf_image_only.name}"
+    assert rel_path in files
+    assert files[rel_path].extracted_count == 0
+
+
+def test_scan_report_pdf_meta_is_populated(
+    tmp_path: Path, pdf_text_simple: Path, pdf_broken_xref: Path, pdf_image_only: Path
+) -> None:
+    root = tmp_path / "repo"
+    target = root / "basic_knowledge" / "method_frame"
+    target.mkdir(parents=True)
+    for source in (pdf_text_simple, pdf_broken_xref, pdf_image_only):
+        shutil.copy(source, target / source.name)
+
+    items, files = parser.scan_directory(target, root, min_pdf_chars=180, pdf_backends=BACKENDS)
+    assert items
+
+    paths = harvest_methods.HarvesterPaths(root, target)
+    timestamp = normalize.now_iso()
+    harvest_methods.write_scan_report(paths, files, timestamp)
+
+    report = json.loads(paths.scan_report_path.read_text(encoding="utf-8"))
+    file_entries = report["files"]
+    for filename in (
+        f"basic_knowledge/method_frame/{pdf_text_simple.name}",
+        f"basic_knowledge/method_frame/{pdf_broken_xref.name}",
+        f"basic_knowledge/method_frame/{pdf_image_only.name}",
+    ):
+        assert filename in file_entries
+        meta = file_entries[filename].get("pdf_meta")
+        assert isinstance(meta, dict)
+        assert meta.get("bytes", 0) > 0
+        assert "backend" in meta
+        assert "chars" in meta
+        assert "warnings" in meta
+        assert "repaired" in meta
+        assert "error" in meta


### PR DESCRIPTION
## Summary
- refine the PDF parser to reshape extracted text, rescore headings, and keep pdf_meta populated during scans
- ensure the scan report directory exists before writing results
- add embedded PDF fixtures with tests plus document/install the optional PDF dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd585e8154832b995cc3dc6a7b018b